### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,26 +6,26 @@
 # Library (KEYWORD1)
 #######################################
 
-PM25 	KEYWORD1
+PM25	KEYWORD1
 pm25	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init 	KEYWORD2
-start 	KEYWORD2
+init	KEYWORD2
+start	KEYWORD2
 stop	KEYWORD2
-read	KEYWORD2 
+read	KEYWORD2
 setAdjustmentCOF	KEYWORD2
 getAdjustmentCOF	KEYWORD2
 enableAutoSend	KEYWORD2
 disableAutoSend	KEYWORD2 
-get	KEYWORD2	
+get	KEYWORD2
 loop	KEYWORD2
-PM01_TYPE KEYWORD2
-PM25_TYPE KEYWORD2
-PM10_TYPE KEYWORD2		
+PM01_TYPE	KEYWORD2
+PM25_TYPE	KEYWORD2
+PM10_TYPE	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords